### PR TITLE
[Feature] 오프라인 스터디 그룹 생성 시 주소 추가

### DIFF
--- a/app/studies/create/page.tsx
+++ b/app/studies/create/page.tsx
@@ -24,6 +24,8 @@ import { auth } from "@/lib/auth"
 import { useAuth } from "@/components/auth-provider"
 import { AVAILABLE_TECH_TAGS, toServerTechTag } from "@/lib/constants/tech-tags"
 import { getTechStacks, TechStack } from "@/lib/api/techStack"
+import { AddressSelector } from "@/components/studies/AddressSelector"
+
 
 interface CreateStudyGroupRequest {
   title: string;
@@ -34,7 +36,7 @@ interface CreateStudyGroupRequest {
   recruitEndDate: string;
   groupMemberCount: number;
   isOffline: boolean;
-  studyLocation: string;
+  addressIds: number[];
   techTags: string[];
 }
 
@@ -69,7 +71,7 @@ export default function CreateStudyPage() {
   const [title, setTitle] = useState("")
   const [description, setDescription] = useState("")
   const [isOnline, setIsOnline] = useState(true)
-  const [location, setLocation] = useState("")
+  const [selectedAddressIds, setSelectedAddressIds] = useState<number[]>([])
   const [maxMembers, setMaxMembers] = useState("6")
 
   const [studyStartDate, setStudyStartDate] = useState<Date>()
@@ -145,7 +147,7 @@ export default function CreateStudyPage() {
     }
 
     // 오프라인 스터디인 경우 장소 검증
-    if (!isOnline && !location) {
+    if (!isOnline && selectedAddressIds.length === 0) {
       toast({
         title: "장소 정보 누락",
         description: "오프라인 스터디의 경우 장소 정보를 입력해주세요.",
@@ -174,7 +176,7 @@ export default function CreateStudyPage() {
         recruitEndDate: format(recruitEndDate, 'yyyy-MM-dd'),
         groupMemberCount: parseInt(maxMembers),
         isOffline: !isOnline,
-        studyLocation: location,
+        addressIds: selectedAddressIds,
         techTags: selectedTags,
       }
 
@@ -350,16 +352,12 @@ export default function CreateStudyPage() {
               </div>
 
               {!isOnline && (
-                <div className="space-y-2">
-                  <Label htmlFor="location">스터디 장소</Label>
-                  <Input
-                    id="location"
-                    placeholder="스터디 장소를 입력하세요 (예: 서울 강남구)"
-                    value={location}
-                    onChange={(e) => setLocation(e.target.value)}
-                  />
-                </div>
+                <AddressSelector
+                  selectedAddressIds={selectedAddressIds}
+                  onChange={setSelectedAddressIds}
+                />
               )}
+
 
               <div className="space-y-2">
                 <Label htmlFor="maxMembers">모집 인원</Label>

--- a/components/studies/AddressSelector.tsx
+++ b/components/studies/AddressSelector.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import { useState, useEffect } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import { api } from "@/lib/api-client";
+
+interface AddressDto {
+  id: number | null;
+  city: string;
+  gu: string;
+  dong: string | null;
+}
+
+interface AddressSelectorProps {
+  selectedAddressIds: number[];
+  onChange: (ids: number[]) => void;
+}
+
+export function AddressSelector({ selectedAddressIds, onChange }: AddressSelectorProps) {
+  const [cities, setCities] = useState<AddressDto[]>([]);
+  const [gus, setGus] = useState<AddressDto[]>([]);
+  const [dongs, setDongs] = useState<AddressDto[]>([]);
+
+  // 선택된 동 상세 정보를 별도로 관리
+  const [selectedAddresses, setSelectedAddresses] = useState<AddressDto[]>([]);
+
+  const [selectedCity, setSelectedCity] = useState("");
+  const [selectedGu, setSelectedGu] = useState("");
+
+  // 시 목록 로드
+  useEffect(() => {
+    api.get("/addresses/cities").then((res) => {
+      setCities(res.result);
+    });
+  }, []);
+
+  // 구 목록 로드
+  useEffect(() => {
+    if (selectedCity) {
+      api.get(`/addresses/gus?city=${selectedCity}`).then((res) => {
+        setGus(res.result);
+        setSelectedGu("");
+        setDongs([]);
+      });
+    } else {
+      setGus([]);
+      setSelectedGu("");
+      setDongs([]);
+    }
+  }, [selectedCity]);
+
+  // 동 목록 로드
+  useEffect(() => {
+    if (selectedCity && selectedGu) {
+      api.get(`/addresses/dongs?city=${selectedCity}&gu=${selectedGu}`).then((res) => {
+        setDongs(res.result);
+      });
+    } else {
+      setDongs([]);
+    }
+  }, [selectedCity, selectedGu]);
+
+  // selectedAddressIds 상태 변경에 맞춰 selectedAddresses 동기화
+  // 선택된 id들로부터 이름 등 상세정보를 동기화
+  useEffect(() => {
+    // 현재 selectedAddressIds에 없어진 id는 제거, 새로 추가된 id는 dongs 데이터에서 찾기
+    setSelectedAddresses(prevSelected => {
+      // 필터해서 현재 id 목록에 있는 것만 남기기
+      const filtered = prevSelected.filter(addr => selectedAddressIds.includes(addr.id ?? -1));
+
+      // id 중에서 prevSelected에 없는 id 찾아서 추가
+      const missingIds = selectedAddressIds.filter(id => !filtered.some(addr => addr.id === id));
+
+      const missingAddresses = dongs.filter(dong => dong.id !== null && missingIds.includes(dong.id));
+
+      return [...filtered, ...missingAddresses];
+    });
+  }, [selectedAddressIds, dongs]);
+
+  // 동 선택 추가
+  const handleAddDong = (dong: AddressDto) => {
+    if (dong.dong && dong.id !== null && !selectedAddressIds.includes(dong.id)) {
+      const newIds = [...selectedAddressIds, dong.id];
+      onChange(newIds);
+
+      // selectedAddresses는 useEffect에서 자동 동기화 됨
+    }
+  };
+
+  // 선택 제거
+  const handleRemoveDong = (id: number) => {
+    const newIds = selectedAddressIds.filter((d) => d !== id);
+    onChange(newIds);
+
+    // selectedAddresses는 useEffect에서 자동 동기화 됨
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium">스터디 장소</label>
+      <div className="flex gap-2">
+        {/* 시 선택 */}
+        <Select value={selectedCity} onValueChange={setSelectedCity}>
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="시" />
+          </SelectTrigger>
+          <SelectContent>
+            {cities.map((cityObj, index) => (
+              <SelectItem key={cityObj.id ?? `city-${index}`} value={cityObj.city ?? ""}>
+                {cityObj.city ?? "Unknown City"}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* 구 선택 */}
+        <Select value={selectedGu} onValueChange={setSelectedGu} disabled={!selectedCity}>
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="구" />
+          </SelectTrigger>
+          <SelectContent>
+            {gus.map((guObj, index) => (
+              <SelectItem key={guObj.id ?? `gu-${index}`} value={guObj.gu ?? ""}>
+                {guObj.gu ?? "Unknown Gu"}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* 동 선택 */}
+        <Select
+          value={""} // 빈 문자열로 값 고정해서 여러번 선택 가능하게
+          onValueChange={(id) => {
+            const dong = dongs.find((d) => d.id?.toString() === id);
+            if (dong) {
+              handleAddDong(dong);
+            }
+          }}
+          disabled={!selectedGu}
+        >
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="동" />
+          </SelectTrigger>
+          <SelectContent>
+            {dongs
+              .filter((dong) => typeof dong.dong === "string" && dong.dong.trim() !== "" && dong.id !== null)
+              .map((dong, index) => (
+                <SelectItem key={dong.id ?? `dong-${index}`} value={dong.id?.toString() ?? ""}>
+                  {dong.dong}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* 선택된 동 리스트 */}
+      <div className="flex flex-wrap gap-2 mt-2">
+        {selectedAddresses.map((dong, index) => {
+          if (!dong?.dong) return null;
+          return (
+            <Badge key={dong.id ?? `selected-${index}`} variant="secondary" className="flex items-center gap-1">
+              {dong.dong}
+              <X className="h-3 w-3 cursor-pointer" onClick={() => dong.id !== null && handleRemoveDong(dong.id)} />
+            </Badge>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
#4 
closes #4 

기능 개요
- 오프라인 스터디 그룹 생성 시 하나 이상의 주소 등록 가능 

<img width="713" height="234" alt="image" src="https://github.com/user-attachments/assets/86e5aaae-ad1d-4165-a867-975e58643805" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 스터디 생성 시 오프라인 위치 입력이 주소 선택 기능으로 개선되었습니다. 사용자는 단계별(시/구/동)로 주소를 선택할 수 있으며, 여러 동을 선택할 수 있습니다.

* **개선 사항**
  * 기존의 자유 입력 방식 위치 필드가 주소 선택 컴포넌트로 대체되어, 보다 정확한 위치 선택과 검증이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->