### PR TITLE
[Fix] 스터디 그룹 주소 관련 코드 수정

### DIFF
--- a/app/studies/edit/[id]/page.tsx
+++ b/app/studies/edit/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useRouter, useParams } from "next/navigation"
 import { useForm } from "react-hook-form"
 import { useToast } from "@/hooks/use-toast"
@@ -8,19 +8,20 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { Checkbox } from "@/components/ui/checkbox"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { getTechStacks, TechStack } from "@/lib/api/techStack"
-import { Calendar, MapPin, Users } from "lucide-react"
 import { api } from "@/lib/api-client"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select"
+import { AddressSelector } from "@/components/studies/AddressSelector"
 
 interface StudySettingsForm {
   title: string
   description: string
   isOnline: boolean
-  location: string
+  addressIds: number[]
   groupLimit: number
   studyStartDate: string
   studyEndDate: string
@@ -29,26 +30,12 @@ interface StudySettingsForm {
   techTags: string[]
 }
 
-// 더미 데이터
-const dummyStudyData = {
-  title: "React 스터디",
-  description: "React와 Next.js를 함께 공부하는 스터디입니다. 실무에서 자주 사용되는 패턴과 최신 기술을 학습합니다.",
-  isOnline: true,
-  location: "서울 강남구",
-  groupLimit: 6,
-  studyStartDate: "2024-03-01",
-  studyEndDate: "2024-04-30",
-  recruitStartDate: "2024-02-15",
-  recruitEndDate: "2024-02-28",
-  techTags: ["React", "TypeScript", "Next.js"]
-}
-
 export default function StudyEditPage() {
   const router = useRouter()
   const params = useParams()
   const { toast } = useToast()
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [availableTags, setAvailableTags] = useState<TechStack[]>([])
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [isLoading, setIsLoading] = useState(true)
 
   const {
@@ -60,13 +47,10 @@ export default function StudyEditPage() {
   } = useForm<StudySettingsForm>()
 
   useEffect(() => {
-    getTechStacks().then((tags) => {
-      setAvailableTags(tags)
-    })
+    getTechStacks().then(setAvailableTags)
   }, [])
 
   useEffect(() => {
-    // 실제 스터디 데이터 불러오기
     const fetchStudy = async () => {
       try {
         const response = await api.get(`/study-group/${params.id}`)
@@ -75,15 +59,15 @@ export default function StudyEditPage() {
           setValue("title", study.title)
           setValue("description", study.explanation)
           setValue("isOnline", !study.offline)
-          setValue("location", study.location)
           setValue("groupLimit", study.groupLimit)
           setValue("studyStartDate", study.studyStartDate)
           setValue("studyEndDate", study.studyEndDate)
           setValue("recruitStartDate", study.recruitStartDate)
           setValue("recruitEndDate", study.recruitEndDate)
+          setValue("addressIds", study.addresses.map((a: { id: number }) => a.id))
           setSelectedTags(study.techStacks.map((t: { name: string }) => t.name))
         }
-      } catch (error) {
+      } catch {
         toast({
           title: "스터디 정보를 불러오지 못했습니다.",
           description: "잠시 후 다시 시도해주세요.",
@@ -93,6 +77,7 @@ export default function StudyEditPage() {
         setIsLoading(false)
       }
     }
+
     fetchStudy()
   }, [params.id, setValue, toast])
 
@@ -107,17 +92,18 @@ export default function StudyEditPage() {
         recruitStartDate: data.recruitStartDate,
         recruitEndDate: data.recruitEndDate,
         groupMemberCount: data.groupLimit,
-        isOffline: !data.isOnline ? true : false,
-        studyLocation: data.location,
+        isOffline: !data.isOnline,
+        addressIds: data.addressIds,
         techStackNames: selectedTags,
       }
+
       await api.patch(`/study-group/${params.id}`, requestBody)
       toast({
         title: "설정 저장 완료",
         description: "스터디 설정이 저장되었습니다.",
       })
       router.push(`/studies/${params.id}`)
-    } catch (error) {
+    } catch {
       toast({
         title: "설정 저장 실패",
         description: "스터디 설정 저장 중 오류가 발생했습니다.",
@@ -127,15 +113,13 @@ export default function StudyEditPage() {
   }
 
   const handleTagToggle = (tag: string) => {
-    if (selectedTags.includes(tag)) {
-      setSelectedTags(selectedTags.filter((t) => t !== tag))
-    } else {
-      setSelectedTags([...selectedTags, tag])
-    }
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    )
   }
 
   if (isLoading) {
-    return <div>로딩 중...</div>
+    return <div className="text-center text-muted-foreground py-16">로딩 중...</div>
   }
 
   return (
@@ -154,54 +138,43 @@ export default function StudyEditPage() {
         </TabsList>
 
         <TabsContent value="basic">
-          <Card className="w-full">
+          <Card>
             <CardHeader>
               <CardTitle>기본 정보</CardTitle>
             </CardHeader>
-            <CardContent>
+            <CardContent className="space-y-4">
               <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
                 <div className="space-y-2">
                   <Label htmlFor="title">스터디 제목</Label>
-                  <Input
-                    id="title"
-                    {...register("title", { required: "제목을 입력해주세요" })}
-                  />
-                  {errors.title && (
-                    <p className="text-sm text-red-500">{errors.title.message}</p>
-                  )}
+                  <Input id="title" {...register("title", { required: "제목을 입력해주세요" })} />
+                  {errors.title && <p className="text-red-500 text-sm">{errors.title.message}</p>}
                 </div>
 
                 <div className="space-y-2">
                   <Label htmlFor="description">스터디 설명</Label>
-                  <Textarea
-                    id="description"
-                    {...register("description", { required: "설명을 입력해주세요" })}
-                  />
+                  <Textarea id="description" {...register("description", { required: "설명을 입력해주세요" })} />
                   {errors.description && (
-                    <p className="text-sm text-red-500">{errors.description.message}</p>
+                    <p className="text-red-500 text-sm">{errors.description.message}</p>
                   )}
                 </div>
 
                 <div className="space-y-2">
                   <Label>스터디 방식</Label>
                   <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="isOnline"
-                      {...register("isOnline")}
-                    />
+                    <Checkbox id="isOnline" {...register("isOnline")} />
                     <Label htmlFor="isOnline">온라인 스터디</Label>
                   </div>
                 </div>
 
                 {!watch("isOnline") && (
                   <div className="space-y-2">
-                    <Label htmlFor="location">오프라인 장소</Label>
-                    <Input
-                      id="location"
-                      {...register("location", { required: "장소를 입력해주세요" })}
+                    <Label htmlFor="addressIds">오프라인 장소</Label>
+                    <AddressSelector
+                      selectedAddressIds={watch("addressIds") ?? []}
+                      onChange={(ids) => setValue("addressIds", ids)}
                     />
-                    {errors.location && (
-                      <p className="text-sm text-red-500">{errors.location.message}</p>
+                    {errors.addressIds && (
+                      <p className="text-red-500 text-sm">{errors.addressIds.message as string}</p>
                     )}
                   </div>
                 )}
@@ -211,8 +184,8 @@ export default function StudyEditPage() {
                   <Input
                     id="groupLimit"
                     type="number"
-                    min="2"
-                    max="20"
+                    min={2}
+                    max={20}
                     {...register("groupLimit", {
                       required: "모집 인원을 입력해주세요",
                       min: { value: 2, message: "최소 2명 이상이어야 합니다" },
@@ -220,7 +193,7 @@ export default function StudyEditPage() {
                     })}
                   />
                   {errors.groupLimit && (
-                    <p className="text-sm text-red-500">{errors.groupLimit.message}</p>
+                    <p className="text-red-500 text-sm">{errors.groupLimit.message}</p>
                   )}
                 </div>
 
@@ -249,65 +222,43 @@ export default function StudyEditPage() {
         </TabsContent>
 
         <TabsContent value="schedule">
-          <Card className="w-full">
+          <Card>
             <CardHeader>
               <CardTitle>일정 설정</CardTitle>
             </CardHeader>
-            <CardContent>
+            <CardContent className="space-y-4">
               <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-                <div className="space-y-2">
-                  <Label>스터디 기간</Label>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="studyStartDate">시작일</Label>
-                      <Input
-                        id="studyStartDate"
-                        type="date"
-                        {...register("studyStartDate", { required: "시작일을 선택해주세요" })}
-                      />
-                      {errors.studyStartDate && (
-                        <p className="text-sm text-red-500">{errors.studyStartDate.message}</p>
-                      )}
-                    </div>
-                    <div>
-                      <Label htmlFor="studyEndDate">종료일</Label>
-                      <Input
-                        id="studyEndDate"
-                        type="date"
-                        {...register("studyEndDate", { required: "종료일을 선택해주세요" })}
-                      />
-                      {errors.studyEndDate && (
-                        <p className="text-sm text-red-500">{errors.studyEndDate.message}</p>
-                      )}
-                    </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="studyStartDate">스터디 시작일</Label>
+                    <Input id="studyStartDate" type="date" {...register("studyStartDate", { required: "시작일을 입력해주세요" })} />
+                    {errors.studyStartDate && (
+                      <p className="text-red-500 text-sm">{errors.studyStartDate.message}</p>
+                    )}
+                  </div>
+                  <div>
+                    <Label htmlFor="studyEndDate">스터디 종료일</Label>
+                    <Input id="studyEndDate" type="date" {...register("studyEndDate", { required: "종료일을 입력해주세요" })} />
+                    {errors.studyEndDate && (
+                      <p className="text-red-500 text-sm">{errors.studyEndDate.message}</p>
+                    )}
                   </div>
                 </div>
 
-                <div className="space-y-2">
-                  <Label>모집 기간</Label>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="recruitStartDate">시작일</Label>
-                      <Input
-                        id="recruitStartDate"
-                        type="date"
-                        {...register("recruitStartDate", { required: "시작일을 선택해주세요" })}
-                      />
-                      {errors.recruitStartDate && (
-                        <p className="text-sm text-red-500">{errors.recruitStartDate.message}</p>
-                      )}
-                    </div>
-                    <div>
-                      <Label htmlFor="recruitEndDate">종료일</Label>
-                      <Input
-                        id="recruitEndDate"
-                        type="date"
-                        {...register("recruitEndDate", { required: "종료일을 선택해주세요" })}
-                      />
-                      {errors.recruitEndDate && (
-                        <p className="text-sm text-red-500">{errors.recruitEndDate.message}</p>
-                      )}
-                    </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="recruitStartDate">모집 시작일</Label>
+                    <Input id="recruitStartDate" type="date" {...register("recruitStartDate", { required: "모집 시작일을 입력해주세요" })} />
+                    {errors.recruitStartDate && (
+                      <p className="text-red-500 text-sm">{errors.recruitStartDate.message}</p>
+                    )}
+                  </div>
+                  <div>
+                    <Label htmlFor="recruitEndDate">모집 종료일</Label>
+                    <Input id="recruitEndDate" type="date" {...register("recruitEndDate", { required: "모집 종료일을 입력해주세요" })} />
+                    {errors.recruitEndDate && (
+                      <p className="text-red-500 text-sm">{errors.recruitEndDate.message}</p>
+                    )}
                   </div>
                 </div>
 
@@ -321,4 +272,4 @@ export default function StudyEditPage() {
       </Tabs>
     </div>
   )
-} 
+}

--- a/components/studies/StudyCard.tsx
+++ b/components/studies/StudyCard.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/navigation"
-import { useCallback, memo } from "react"
+import { useCallback, memo, useEffect } from "react"
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -19,7 +19,11 @@ export interface StudyGroup {
     avatar: string;
   };
   isOnline: boolean;
-  location: string;
+  addresses: {
+    city: string
+    gu: string
+    dong: string
+  }[];
 }
 
 interface StudyCardProps {
@@ -32,6 +36,11 @@ export const StudyCard = memo(function StudyCard({ study }: StudyCardProps) {
   const handleClick = useCallback(() => {
     router.push(`/studies/${study.id}`)
   }, [study.id])
+
+  useEffect(() => {
+    console.log("📍 study.tags", study.tags)
+    console.log("📍 study.addresses", study.addresses)
+  }, [study])
   
   return (
     <Card 
@@ -52,22 +61,26 @@ export const StudyCard = memo(function StudyCard({ study }: StudyCardProps) {
           </Badge>
         </div>
       </CardHeader>
-      <CardContent className="p-4 pt-0">
-        <p className="text-sm text-muted-foreground line-clamp-2 h-10">{study.description}</p>
-        {study.location && (
-          <p className="text-sm text-muted-foreground mt-2 flex items-center">
-            <MapPin className="h-3.5 w-3.5 mr-1 flex-shrink-0 group-hover:text-primary transition-colors" />
-            <span className="truncate">{study.location}</span>
-          </p>
-        )}
-        <div className="flex flex-wrap gap-1.5 mt-3">
-          {study.tags?.map((tag) => (
-            <Badge key={tag.id + '-' + tag.name} variant="secondary" className="font-normal">
-              {tag.name}
-            </Badge>
-          ))}
-        </div>
-      </CardContent>
+        <CardContent className="p-4 pt-0">
+          <p className="text-sm text-muted-foreground line-clamp-2 h-10">{study.description}</p>
+          
+          {!study.isOnline && study.addresses?.[0]?.dong && (
+            <p className="text-sm text-muted-foreground mt-2 flex items-center">
+              <MapPin className="h-3.5 w-3.5 mr-1 flex-shrink-0 group-hover:text-primary transition-colors" />
+              <span className="truncate">{study.addresses[0].dong}</span>
+            </p>
+          )}
+
+
+          <div className="flex flex-wrap gap-1.5 mt-3">
+            {study.tags?.map((tag) => (
+              <Badge key={tag.id + '-' + tag.name} variant="secondary" className="font-normal">
+                {tag.name}
+              </Badge>
+            ))}
+          </div>
+        </CardContent>
+
       <CardFooter className="p-4 pt-0 flex justify-between items-center">
         <div className="flex items-center gap-2">
           <Avatar className="h-6 w-6">

--- a/components/studies/StudyInfo.tsx
+++ b/components/studies/StudyInfo.tsx
@@ -6,6 +6,12 @@ interface StudyInfoProps {
 }
 
 export function StudyInfo({ study }: StudyInfoProps) {
+  // 가장 첫 번째 주소만 표시 (예: 서울특별시 강남구 역삼동)
+  const address =
+    study.offline && study.addresses?.length
+      ? `${study.addresses[0].city} ${study.addresses[0].gu} ${study.addresses[0].dong}`
+      : "온라인"
+
   return (
     <div className="grid grid-cols-2 gap-4 mb-8">
       <div className="flex items-center gap-2">
@@ -14,24 +20,24 @@ export function StudyInfo({ study }: StudyInfoProps) {
           모집 기간: {new Date(study.recruitStartDate).toLocaleDateString()} ~{" "}
           {new Date(study.recruitEndDate).toLocaleDateString()}
         </span>
-          </div>
+      </div>
       <div className="flex items-center gap-2">
         <Calendar className="h-5 w-5 text-muted-foreground" />
         <span>
           스터디 기간: {new Date(study.studyStartDate).toLocaleDateString()} ~{" "}
           {new Date(study.studyEndDate).toLocaleDateString()}
         </span>
-          </div>
+      </div>
       <div className="flex items-center gap-2">
         <Users className="h-5 w-5 text-muted-foreground" />
         <span>
           {study.memberCount}/{study.groupLimit}명
         </span>
-          </div>
+      </div>
       <div className="flex items-center gap-2">
         <MapPin className="h-5 w-5 text-muted-foreground" />
-        <span>{study.offline ? study.location : "온라인"}</span>
-          </div>
-        </div>
+        <span>{address}</span>
+      </div>
+    </div>
   )
-} 
+}

--- a/components/studies/manage/StudyHeader.tsx
+++ b/components/studies/manage/StudyHeader.tsx
@@ -9,6 +9,10 @@ interface StudyHeaderProps {
 }
 
 export function StudyHeader({ study }: StudyHeaderProps) {
+  const locationText = study.offline && study.addresses?.length
+    ? `${study.addresses[0].city} ${study.addresses[0].gu} ${study.addresses[0].dong}`
+    : "온라인"
+
   return (
     <div className="mb-8 w-full">
       <div className="flex justify-between items-start">
@@ -63,9 +67,9 @@ export function StudyHeader({ study }: StudyHeaderProps) {
         </div>
         <div className="flex items-center gap-2">
           <MapPin className="h-5 w-5 text-muted-foreground" />
-          <span>{study.offline ? study.location : "온라인"}</span>
+          <span>{locationText}</span>
         </div>
       </div>
     </div>
   )
-} 
+}

--- a/types/study.ts
+++ b/types/study.ts
@@ -19,24 +19,11 @@ export interface Participant {
   nickname: string
 }
 
-export interface StudyGroupDetail {
+export interface AddressDto {
   id: number
-  title: string
-  explanation: string
-  writer: string
-  memberCount: number
-  groupLimit: number
-  location: string
-  recruitStartDate: string
-  recruitEndDate: string
-  studyStartDate: string
-  studyEndDate: string
-  commentCount: number
-  participants: Participant[]
-  comments: Comment[]
-  offline: boolean
-  sessions: StudySession[]
-  memberStatus: "NOT_APPLIED" | "PENDING" | "APPROVED"
+  city: string
+  gu: string
+  dong: string
 }
 
 export interface StudySession {
@@ -47,4 +34,24 @@ export interface StudySession {
   endDate: string
   location: string
   participants: string[]
+}
+
+export interface StudyGroupDetail {
+  id: number
+  title: string
+  explanation: string
+  writer: string
+  memberCount: number
+  groupLimit: number
+  recruitStartDate: string
+  recruitEndDate: string
+  studyStartDate: string
+  studyEndDate: string
+  commentCount: number
+  participants: Participant[]
+  comments: Comment[]
+  offline: boolean
+  sessions: StudySession[]
+  memberStatus: "NOT_APPLIED" | "PENDING" | "APPROVED"
+  addresses: AddressDto[] // ✅ 새로 추가된 필드
 }


### PR DESCRIPTION
#13 
closes #13 

- 스터디 그룹 관련 주소 `location` -> `addresses` 로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 오프라인 스터디 위치 입력 방식이 기존의 단일 문자열에서 여러 주소 선택(복수 주소 선택)으로 변경되었습니다.

* **버그 수정**
  * 주소 선택과 관련된 에러 메시지 및 폼 유효성 메시지가 새로운 주소 방식에 맞게 업데이트되었습니다.

* **UI 개선**
  * 주소 선택 UI가 추가되고, 위치 표시 로직이 여러 주소를 지원하도록 개선되었습니다.
  * 카드, 정보, 헤더 등 위치 표시 영역의 디자인과 메시지 스타일이 통일되고 가독성이 향상되었습니다.

* **정리 및 리팩터링**
  * 불필요한 코드와 임포트가 제거되고, 일부 코드 구조가 간결하게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->