### PR TITLE
[Fix] 스터디 그룹 집계 API 연동 수정

### DIFF
--- a/lib/api/studySchedule.ts
+++ b/lib/api/studySchedule.ts
@@ -161,9 +161,13 @@ export function convertToSchedule(dto: StudyScheduleResponseDto): Schedule {
 
 // 스터디 그룹 집계 조회 API
 export const getStudyGroupAggregation = async (city: string, gu: string) => {
-  const response = await api.get('/study-group/aggregation', {
+  console.log('🔗 API 호출 시작:', `/api/v1/study-group/calculate?city=${city}&gu=${gu}`)
+  
+  const response = await api.get('/study-group/calculate', {
     params: { city, gu }
   });
+  
+  console.log('🔗 API 응답:', response);
   return response;
 };
 


### PR DESCRIPTION
- 스터디 그룹 집계 API 엔드포인트 수정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 스터디 그룹 집계 데이터를 가져오는 API 엔드포인트가 `/study-group/aggregation`에서 `/study-group/calculate`로 변경되었습니다.  
* **기타**
  * API 호출 전후로 요청 URL과 응답 객체가 콘솔에 기록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->