### PR TITLE
[Refactor] 스터디 그룹 목록 주소 표기 수정

### DIFF
--- a/components/studies/StudyCard.tsx
+++ b/components/studies/StudyCard.tsx
@@ -64,10 +64,12 @@ export const StudyCard = memo(function StudyCard({ study }: StudyCardProps) {
         <CardContent className="p-4 pt-0">
           <p className="text-sm text-muted-foreground line-clamp-2 h-10">{study.description}</p>
           
-          {!study.isOnline && study.addresses?.[0]?.dong && (
+          {!study.isOnline && study.addresses?.length > 0 && (
             <p className="text-sm text-muted-foreground mt-2 flex items-center">
               <MapPin className="h-3.5 w-3.5 mr-1 flex-shrink-0 group-hover:text-primary transition-colors" />
-              <span className="truncate">{study.addresses[0].dong}</span>
+              <span className="truncate">
+                {study.addresses.map(a => a.dong).join(", ")}
+              </span>
             </p>
           )}
 


### PR DESCRIPTION
- 스터디 그룹 리스트를 조회할 때 설정한 모든 주소를 보여주도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 스터디 카드에서 주소가 여러 개인 경우 모든 주소의 동 정보를 쉼표로 구분하여 표시하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->